### PR TITLE
Markdown injection support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
     "files.exclude": {
         "out": false, // set this to true to hide the "out" folder with the compiled JS files
         "dist": false // set this to true to hide the "dist" folder with the compiled JS files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- LDF language included within markdown blocks are highlighted
+
 ## [0.2.0] - 2021-11-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "lin"
     ],
     "license": "MIT",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "preview": true,
     "publisher": "c4deszes",
     "repository": {
@@ -42,7 +42,13 @@
             {
                 "language": "ldf",
                 "scopeName": "source.ldf",
-                "path": "./syntaxes/ldf.tmLanguage.json"
+                "path": "./syntaxes/ldf.tmLanguage.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.ldf": "ldf"
+                }
             }
         ],
         "snippets": [

--- a/syntaxes/ldf.tmLanguage.json
+++ b/syntaxes/ldf.tmLanguage.json
@@ -1,5 +1,6 @@
 {
     "scopeName": "source.ldf",
+    "injectionSelector": "L:text.html.markdown",
     "patterns": [
         {
             "include": "#comment"


### PR DESCRIPTION
## Brief

When `ldf` block is used within markdown files it will now be highlighted.

### Checklist

- [x] Check test result and code coverage
- [x] Update documentation
- [x] Update changelog
- [x] Update version number
