### PR TITLE
Provides symbol information in the outline

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,10 +2,17 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
+import {LdfDocumentSymbolProvider} from "./symbols";
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-
+    context.subscriptions.push(
+        vscode.languages.registerDocumentSymbolProvider(
+            {scheme: 'file', language: 'ldf'},
+            new LdfDocumentSymbolProvider()
+        )
+    );
 }
 
 // this method is called when your extension is deactivated

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,0 +1,38 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+function createFieldSymbol(name: string, line: vscode.TextLine) {
+    return new vscode.DocumentSymbol(name, 'field', vscode.SymbolKind.Field, line.range, line.range);
+}
+
+function createGroupSymbol(name: string, line: vscode.TextLine) {
+    return new vscode.DocumentSymbol(name, 'group', vscode.SymbolKind.Namespace, line.range, line.range);
+}
+
+export class LdfDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+    
+    provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
+        return new Promise((resolve, reject) => {
+            let symbols: vscode.DocumentSymbol[] = [];
+
+            for (let i = 0; i < document.lineCount; i++) {
+                let line = document.lineAt(i);
+
+                if (line.text.startsWith('LIN_protocol_version')) {
+                    symbols.push(createFieldSymbol('protocol_version', line));
+                }
+                else if (line.text.startsWith('LIN_language_version')) {
+                    symbols.push(createFieldSymbol('language_version', line));
+                }
+                else if (line.text.startsWith('LIN_speed')) {
+                    symbols.push(createFieldSymbol('speed', line));
+                }
+                else if (line.text.startsWith('Channel_name')) {
+                    symbols.push(createFieldSymbol('channel', line));
+                }
+            }
+            resolve(symbols);
+        });
+    }
+}


### PR DESCRIPTION
## Brief

Registers a document symbol provider which lists signals, fields, etc. in the document's outline.

### Checklist

- [ ] Check test result and code coverage
- [ ] Update documentation
- [ ] Update changelog
- [ ] Update version number

